### PR TITLE
Pass all the params for onRowsRendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.1
 - Pass all four params to OnRowsRenderer
+- Updated to scala.js 0.6.22
 
 ## 0.1.0
 - Updated to version 9.18.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+## 0.1.1
+- Pass all four params to OnRowsRenderer
+
 ## 0.1.0
 - Updated to version 9.18.5
 - Renamed Table.scrollToRow to Table.scrollToRowCB

--- a/facade/src/main/scala/react/virtualized/Table.scala
+++ b/facade/src/main/scala/react/virtualized/Table.scala
@@ -254,7 +254,7 @@ object Table {
       onRowMouseOut: OnRowClick = _ => Callback.empty,
       onRowMouseOver: OnRowClick = _ => Callback.empty,
       onRowRightClick: OnRowClick = _ => Callback.empty,
-      onRowsRendered: OnRowsRenderer = (_, _) => Callback.empty,
+      onRowsRendered: OnRowsRenderer = (_, _, _, _) => Callback.empty,
       onScroll: OnScroll = (_, _, _) => Callback.empty,
       overscanRowCount: Int = 10, // default from react-virtualized
       rowClassName: String | RowClassName = null,
@@ -302,7 +302,7 @@ object Table {
     p.onRowRightClick = (x: RawIndexParameter) =>
       onRowRightClick(x.index).runNow()
     p.onRowsRendered = (x: RawRowsRendererParam) =>
-      onRowsRendered(x.startIndex, x.stopIndex).runNow()
+      onRowsRendered(x.overscanStartIndex, x.overscanStopIndex, x.startIndex, x.stopIndex).runNow()
     p.onScroll = (x: RawScrollParam) =>
       onScroll(x.clientHeight, x.scrollHeight, x.scrollTop).runNow()
     p.overscanRowCount = overscanRowCount

--- a/facade/src/main/scala/react/virtualized/package.scala
+++ b/facade/src/main/scala/react/virtualized/package.scala
@@ -95,7 +95,7 @@ package object virtualized {
 
   type OnHeaderClick = (js.Object, String) => Callback
 
-  type OnRowsRenderer = (Int, Int) => Callback
+  type OnRowsRenderer = (Int, Int, Int, Int) => Callback
 
   type OnScroll = (JsNumber, JsNumber, JsNumber) => Callback
 
@@ -364,12 +364,16 @@ package virtualized {
 
     // Rows renderer event
     trait RawRowsRendererParam extends js.Object {
+      var overscanStartIndex: Int
+      var overscanStopIndex: Int
       var startIndex: Int
       var stopIndex: Int
     }
     object RawRowsRendererParam {
-      def apply(startIndex: Int, stopIndex: Int): RawRowsRendererParam = {
+      def apply(overscanStartIndex: Int, overscanStopIndex: Int, startIndex: Int, stopIndex: Int): RawRowsRendererParam = {
         val p = (new js.Object).asInstanceOf[RawRowsRendererParam]
+        p.overscanStartIndex = overscanStartIndex
+        p.overscanStopIndex = overscanStopIndex
         p.startIndex = startIndex
         p.stopIndex = stopIndex
         p

--- a/facade/src/test/scala/react/virtualized/TableSpec.scala
+++ b/facade/src/test/scala/react/virtualized/TableSpec.scala
@@ -332,9 +332,9 @@ class TableSpec extends FlatSpec with Matchers with NonImplicitAssertions with T
     it should "support on rows renderer callback" in {
       val columns = List(Column(Column.props(200, "key")))
       val table = Table(Table.props(rowHeight = 20, headerHeight = 10, height = 200, rowCount = 1, width = 500, rowGetter = rowGetterF), columns: _*)
-      table.props.onRowsRendered(RawRowsRendererParam(1, 10)) should be(())
-      val table2 = Table(Table.props(onRowsRendered = (_, _) => Callback.empty, rowHeight = 20, headerHeight = 10, height = 200, rowCount = 1, width = 500, rowGetter = rowGetterF), columns: _*)
-      table2.props.onRowsRendered(RawRowsRendererParam(1, 10)) should be(())
+      table.props.onRowsRendered(RawRowsRendererParam(1, 10, 1, 10)) should be(())
+      val table2 = Table(Table.props(onRowsRendered = (_, _, _, _) => Callback.empty, rowHeight = 20, headerHeight = 10, height = 200, rowCount = 1, width = 500, rowGetter = rowGetterF), columns: _*)
+      table2.props.onRowsRendered(RawRowsRendererParam(1, 10, 1, 10)) should be(())
     }
     it should "support on scroll callback" in {
       val columns = List(Column(Column.props(200, "key")))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.21")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.9.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.10.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 


### PR DESCRIPTION
`onRowsRendered` takes 4 params instead of the 2 mentioned on the code documentation